### PR TITLE
Feature/update note: Full & Partial Note Updates

### DIFF
--- a/api/controllers/note.controller.js
+++ b/api/controllers/note.controller.js
@@ -167,6 +167,46 @@ export const deleteNote = async (req, res) => {
     }
 };
 
+// Update a note by ID
+export const updateNote = async (req, res) => {
+    try {
+        const { noteID } = req.params;
+        const { title, content } = req.body;
+
+        if (!mongoose.Types.ObjectId.isValid(noteID)) {
+            return res.status(400).json({ message: "Invalid Note ID format." });
+        }
+
+        if (!title || !content || !title.trim() || !content.trim()) {
+            return res.status(400).json({
+                message: "Title and content are required fields.",
+            });
+        }
+
+        const updatedNote = await Note.findByIdAndUpdate(
+            noteID,
+            { title, content, updatedAt: new Date() },
+            { new: true, runValidators: true }
+        );
+
+        if (!updatedNote) {
+            return res.status(404).json({ message: "Note not found." });
+        }
+
+        res.status(200).json({
+            message: "Note updated successfully",
+            note: updatedNote,
+            request: {
+                type: "GET",
+                url: `http://localhost:3000/notes/${updatedNote._id}`,
+            },
+        });
+    } catch (error) {
+        console.error("Error updating note:", error);
+        res.status(500).json({ error: error.message });
+    }
+};
+
 /* for training purposes */
 const getAllNotesUsingNormalFiltering = async (req, res) => {
     try {

--- a/api/controllers/note.controller.js
+++ b/api/controllers/note.controller.js
@@ -207,6 +207,52 @@ export const updateNote = async (req, res) => {
     }
 };
 
+// Partially update a note (title, content, or both)
+export const partiallyUpdateNote = async (req, res) => {
+    try {
+        const { noteID } = req.params;
+        const { title, content } = req.body;
+
+        if (!mongoose.Types.ObjectId.isValid(noteID)) {
+            return res.status(400).json({ message: "Invalid Note ID format." });
+        }
+
+        if (!title?.trim() && !content?.trim()) {
+            return res.status(400).json({
+                message:
+                    "At least one of title or content is required for update.",
+            });
+        }
+
+        const updateFields = {};
+        if (title?.trim()) updateFields.title = title.trim();
+        if (content?.trim()) updateFields.content = content.trim();
+        updateFields.updatedAt = new Date();
+
+        const updatedNote = await Note.findByIdAndUpdate(
+            noteID,
+            { $set: updateFields },
+            { new: true, runValidators: true }
+        );
+
+        if (!updatedNote) {
+            return res.status(404).json({ message: "Note not found." });
+        }
+
+        res.status(200).json({
+            message: "Note updated successfully",
+            note: updatedNote,
+            request: {
+                type: "GET",
+                url: `http://localhost:3000/notes/${updatedNote._id}`,
+            },
+        });
+    } catch (error) {
+        console.error("Error updating note:", error);
+        res.status(500).json({ error: error.message });
+    }
+};
+
 /* for training purposes */
 const getAllNotesUsingNormalFiltering = async (req, res) => {
     try {

--- a/api/routes/notes.js
+++ b/api/routes/notes.js
@@ -5,6 +5,7 @@ import {
     getNoteByID,
     addNote,
     deleteNote,
+    updateNote,
 } from "../controllers/note.controller.js";
 const router = express.Router();
 
@@ -12,6 +13,7 @@ router.get("/", getAllNotes);
 router.get("/search", searchNotes);
 router.get("/:noteID", getNoteByID);
 router.delete("/:noteID", deleteNote);
+router.put("/:noteID", updateNote);
 router.post("/", addNote);
 
 export default router;

--- a/api/routes/notes.js
+++ b/api/routes/notes.js
@@ -6,6 +6,7 @@ import {
     addNote,
     deleteNote,
     updateNote,
+    partiallyUpdateNote,
 } from "../controllers/note.controller.js";
 const router = express.Router();
 
@@ -14,6 +15,7 @@ router.get("/search", searchNotes);
 router.get("/:noteID", getNoteByID);
 router.delete("/:noteID", deleteNote);
 router.put("/:noteID", updateNote);
+router.patch("/:noteID", partiallyUpdateNote);
 router.post("/", addNote);
 
 export default router;


### PR DESCRIPTION
### **Description**
This PR introduces two new API endpoints to update notes:  
- **`PUT /notes/:id`** → Fully update a note (both `title` and `content` are required).  
- **`PATCH /notes/:id`** → Partially update a note (either `title`, `content`, or both).  

### **Changes Made**
- **Added `PUT /notes/:id`** for full updates.  
- **Added `PATCH /notes/:id`** for partial updates.  
- **Validation Improvements:**  
  - Ensures `noteID` is a valid MongoDB ObjectID.  
  - `PUT` requires both `title` and `content`.  
  - `PATCH` allows updating only `title`, `content`, or both.  
- **Updated Routes:**
  ```javascript
  router.put("/:noteID", updateNote);
  router.patch("/:noteID", partiallyUpdateNote);
